### PR TITLE
fix: pass `dotfiles` option to `serve-static`

### DIFF
--- a/src/static_middleware.ts
+++ b/src/static_middleware.ts
@@ -54,8 +54,11 @@ export default class StaticMiddleware {
    * ```
    */
   constructor(publicPath: string, config: AssetsConfig) {
+    const { dotFiles, ...rest } = config
+
     this.#sendFile = staticServer(publicPath, {
-      ...config,
+      ...rest,
+      dotfiles: dotFiles,
       fallthrough: true,
       setHeaders: (res, path, stats) => {
         const headers = res.parent!.getHeaders()

--- a/tests/static_middleware.spec.ts
+++ b/tests/static_middleware.spec.ts
@@ -136,7 +136,7 @@ test.group('Serve Static', (group) => {
     assert.equal(Buffer.from(res.body).toString(), 'merchant-id-content')
   })
 
-  test('ignore dotfiles by default', async ({ assert }) => {
+  test('ignore dotfiles by default', async () => {
     await fs.outputFile(join(BASE_PATH, 'public/.env'), 'SECRET=123')
 
     const server = createServer(async (req, res) => {

--- a/tests/static_middleware.spec.ts
+++ b/tests/static_middleware.spec.ts
@@ -107,6 +107,54 @@ test.group('Serve Static', (group) => {
     assert.equal(text, 'Route not found')
   })
 
+  test('serve files inside dotfile directories when dotFiles is allow', async ({ assert }) => {
+    await fs.outputFile(
+      join(BASE_PATH, 'public/.well-known/apple-developer-merchantid-domain-association'),
+      'merchant-id-content'
+    )
+
+    const server = createServer(async (req, res) => {
+      const serveStatic = new StaticMiddleware(
+        join(BASE_PATH, 'public'),
+        defineConfig({ dotFiles: 'allow' })
+      )
+
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+
+      await serveStatic.handle(ctx, () => {
+        ctx.response.status(404).send('404')
+        ctx.response.finish()
+      })
+    })
+
+    const res = await supertest(server)
+      .get('/.well-known/apple-developer-merchantid-domain-association')
+      .expect(200)
+
+    assert.equal(Buffer.from(res.body).toString(), 'merchant-id-content')
+  })
+
+  test('ignore dotfiles by default', async ({ assert }) => {
+    await fs.outputFile(join(BASE_PATH, 'public/.env'), 'SECRET=123')
+
+    const server = createServer(async (req, res) => {
+      const serveStatic = new StaticMiddleware(join(BASE_PATH, 'public'), defineConfig({}))
+
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+
+      await serveStatic.handle(ctx, () => {
+        ctx.response.status(404).send('404')
+        ctx.response.finish()
+      })
+    })
+
+    await supertest(server).get('/.env').expect(404)
+  })
+
   test('set headers defined via config', async ({ assert }) => {
     await fs.outputFile(join(BASE_PATH, 'public/style.css'), 'body { background: #000 }')
 


### PR DESCRIPTION
Close #3 

Map `dotFiles` ( camelCase) to `dotfiles` (lowercase) expected by serve-static/send

the casing mismatch has always been there => `dotFiles` was never actually passed to `serve-static` , which expects `dotfiles`

but nobody noticed because send v0.x (used by serve-static v1) had a legacy fallback: when `dotfiles` was undefined, it would still allow requests to files nested inside dotfile directories (like `/.well-known/stuff`) , only blocking direct dotfiles (like `/.env`). so the `.well-known` use case worked by accident

with the bump to serve-static v2 / send v1, that legacy fallback was removed. now when dotfiles is undefined, it defaults to 'ignore' for everything including dotfile directories